### PR TITLE
Add callback option on malloc failure

### DIFF
--- a/src/umm_malloc.c
+++ b/src/umm_malloc.c
@@ -425,6 +425,10 @@ void *umm_malloc( size_t size ) {
     /* Release the critical section... */
     UMM_CRITICAL_EXIT();
 
+	/* No free space. Notify application if callback is configured*/
+#if UMM_NOHEAP_CALLBACK_ENABLE
+	UMM_NOHEAP_CALLBACK_FUNC(size);
+#endif
     return( (void *)NULL );
   }
 

--- a/src/umm_malloc_cfg.h
+++ b/src/umm_malloc_cfg.h
@@ -56,6 +56,10 @@ extern char test_umm_heap[];
 /* Start addresses and the size of the heap */
 #define UMM_MALLOC_CFG_HEAP_ADDR (test_umm_heap)
 #define UMM_MALLOC_CFG_HEAP_SIZE 0x10000
+/* Call external function of signature void callback(size_t) 
+   when no space available to malloc */
+#define UMM_NOHEAP_CALLBACK_ENABLE 0
+#define UMM_NOHEAP_CALLBACK_FUNC 
 
 /* A couple of macros to make packing structures less compiler dependent */
 


### PR DESCRIPTION
When you don't have acces to other libs using malloc and they don't check for malloc return null, it is useful to have a callback for debugging and restarting in a controlled way.