### PR TITLE
Unnest critical sections in realloc

### DIFF
--- a/src/umm_malloc.c
+++ b/src/umm_malloc.c
@@ -314,7 +314,7 @@ void umm_free( void *ptr ) {
   UMM_CRITICAL_ENTRY();
 
   /* Call the core logic */
-  umm_free_unsafe();
+  umm_free_unsafe(ptr);
 
   /* Release the critical section... */
   UMM_CRITICAL_EXIT();

--- a/src/umm_malloc.c
+++ b/src/umm_malloc.c
@@ -456,7 +456,7 @@ void *umm_malloc( size_t size ) {
   /* Protect the critical section... */
   UMM_CRITICAL_ENTRY();
 
-  ret = umm_malloc_unsafe(size);
+  ptr = umm_malloc_unsafe(size);
 
   /* Release the critical section... */
   UMM_CRITICAL_EXIT();

--- a/src/umm_malloc.c
+++ b/src/umm_malloc.c
@@ -247,18 +247,12 @@ void umm_init( void ) {
 }
 
 /* ------------------------------------------------------------------------ */
-
-void umm_free( void *ptr ) {
+/* Meant to be called only from within critical sections guarded by 
+ * UMM_CRITICAL_ENTRY() and UMM_CRITICAL_EXIT().
+ */
+static void umm_free_unsafe( void *ptr ) {
 
   unsigned short int c;
-
-  /* If we're being asked to free a NULL pointer, well that's just silly! */
-
-  if( (void *)0 == ptr ) {
-    DBGLOG_DEBUG( "free a null pointer -> do nothing\n" );
-
-    return;
-  }
 
   /*
    * FIXME: At some point it might be a good idea to add a check to make sure
@@ -268,9 +262,6 @@ void umm_free( void *ptr ) {
    * NOTE:  See the new umm_info() function that you can use to see if a ptr is
    *        on the free list!
    */
-
-  /* Protect the critical section... */
-  UMM_CRITICAL_ENTRY();
 
   /* Figure out which block we're in. Note the use of truncated division... */
 
@@ -305,13 +296,39 @@ void umm_free( void *ptr ) {
     UMM_NBLOCK(c)          |= UMM_FREELIST_MASK;
   }
 
+}
+
+/* ------------------------------------------------------------------------ */
+
+void umm_free( void *ptr ) {
+
+  /* If we're being asked to free a NULL pointer, well that's just silly! */
+
+  if( (void *)0 == ptr ) {
+    DBGLOG_DEBUG( "free a null pointer -> do nothing\n" );
+
+    return;
+  }
+
+  /* Protect the critical section... */
+  UMM_CRITICAL_ENTRY();
+
+  /* Call the core logic */
+  umm_free_unsafe();
+
   /* Release the critical section... */
   UMM_CRITICAL_EXIT();
 }
 
 /* ------------------------------------------------------------------------ */
+/* Meant to be called only from within critical sections guarded by 
+ * UMM_CRITICAL_ENTRY() and UMM_CRITICAL_EXIT().
+ *
+ * Assumes that size is not zero, and that umm is already inited.
+ */
 
-void *umm_malloc( size_t size ) {
+static void *umm_malloc_unsafe( size_t size ) {
+  
   unsigned short int blocks;
   unsigned short int blockSize = 0;
 
@@ -319,26 +336,6 @@ void *umm_malloc( size_t size ) {
   unsigned short int bestBlock;
 
   unsigned short int cf;
-
-  if (umm_heap == NULL) {
-    umm_init();
-  }
-
-  /*
-   * the very first thing we do is figure out if we're being asked to allocate
-   * a size of 0 - and if we are we'll simply return a null pointer. if not
-   * then reduce the size by 1 byte so that the subsequent calculations on
-   * the number of blocks to allocate are easier...
-   */
-
-  if( 0 == size ) {
-    DBGLOG_DEBUG( "malloc a block of 0 bytes -> do nothing\n" );
-
-    return( (void *)NULL );
-  }
-
-  /* Protect the critical section... */
-  UMM_CRITICAL_ENTRY();
 
   blocks = umm_blocks( size );
 
@@ -427,16 +424,44 @@ void *umm_malloc( size_t size ) {
 
     DBGLOG_DEBUG(  "Can't allocate %5i blocks\n", blocks );
 
-    /* Release the critical section... */
-    UMM_CRITICAL_EXIT();
-
     return( (void *)NULL );
   }
+
+  return( (void *)&UMM_DATA(cf) );
+}
+
+/* ------------------------------------------------------------------------ */
+
+void *umm_malloc( size_t size ) {
+
+  void *ptr = NULL;
+  
+  if (umm_heap == NULL) {
+    umm_init();
+  }
+
+  /*
+   * the very first thing we do is figure out if we're being asked to allocate
+   * a size of 0 - and if we are we'll simply return a null pointer. if not
+   * then reduce the size by 1 byte so that the subsequent calculations on
+   * the number of blocks to allocate are easier...
+   */
+
+  if( 0 == size ) {
+    DBGLOG_DEBUG( "malloc a block of 0 bytes -> do nothing\n" );
+
+    return( ptr ); //NULL return
+  }
+
+  /* Protect the critical section... */
+  UMM_CRITICAL_ENTRY();
+
+  ret = umm_malloc_unsafe(size);
 
   /* Release the critical section... */
   UMM_CRITICAL_EXIT();
 
-  return( (void *)&UMM_DATA(cf) );
+  return( ptr );
 }
 
 /* ------------------------------------------------------------------------ */
@@ -577,10 +602,10 @@ void *umm_realloc( void *ptr, size_t size ) {
     } else {
         DBGLOG_DEBUG( "realloc a completely new block %i\n", blocks );
         void *oldptr = ptr;
-        if( (ptr = umm_malloc( size )) ) {
+        if( (ptr = umm_malloc_unsafe( size )) ) {
             DBGLOG_DEBUG( "realloc %i to a bigger block %i, copy, and free the old\n", blockSize, blocks );
             memcpy( ptr, oldptr, curSize );
-            umm_free( oldptr );
+            umm_free_unsafe( oldptr ); //call unsafe, because already in critical section
         } else {
             DBGLOG_DEBUG( "realloc %i to a bigger block %i failed - return NULL and leave the old block!\n", blockSize, blocks );
             /* This space intentionally left blnk */
@@ -595,7 +620,7 @@ void *umm_realloc( void *ptr, size_t size ) {
     if (blockSize > blocks ) {
         DBGLOG_DEBUG( "split and free %i blocks from %i\n", blocks, blockSize );
         umm_split_block( c, blocks, 0 );
-        umm_free( (void *)&UMM_DATA(c+blocks) );
+        umm_free_unsafe( (void *)&UMM_DATA(c+blocks) ); //call unsafe, because already in critical section
     }
 
     /* Release the critical section... */


### PR DESCRIPTION
Unnest critical sections in realloc() by refactoring free() and malloc() each into two functions: am unsafe core and a wrapper that calls the core within crtical section guards.

Fixes #15 