### PR TITLE
Fix crash if umm_info called before heap is initialised

### DIFF
--- a/src/umm_info.c
+++ b/src/umm_info.c
@@ -18,6 +18,9 @@
 UMM_HEAP_INFO ummHeapInfo;
 
 void *umm_info( void *ptr, int force ) {
+  if(umm_heap == NULL) {
+    umm_init();
+  }
 
   unsigned short int blockNo = 0;
 


### PR DESCRIPTION
I discovered this issue building against Espressif NON-OS SDK version 3.0.1. At some point since version 2.0.0 there's a call been added which calls `umm_free_heap_size()` before any allocations have taken place. This PR detects the uninitialised condition and performs the heap initialisation so the call can succeed, otherwise it just crashes accessing a NULL pointer.

Fixes #20.