### PR TITLE
[UMM-27] Move metric calculations to umm_info.c

### DIFF
--- a/src/umm_malloc.h
+++ b/src/umm_malloc.h
@@ -20,14 +20,6 @@ extern void *umm_calloc( size_t num, size_t size );
 extern void *umm_realloc( void *ptr, size_t size );
 extern void  umm_free( void *ptr );
 
-#ifdef UMM_METRICS
-extern int umm_fragmentation_metric( void );
-extern int umm_fragmentation_metric_freeblocks( void );
-#else
-#define umm_fragmentation_metric() (0)
-#define umm_fragmentation_freeblocks() (0)
-#endif // UMM_METRICS
-
 /* ------------------------------------------------------------------------ */
 
 #ifdef __cplusplus

--- a/src/umm_malloc_cfg.h
+++ b/src/umm_malloc_cfg.h
@@ -27,12 +27,6 @@
  * Set this if you want to use a first-fit algorithm for allocating new
  * blocks
  *
- * -D UMM_METRICS
- *
- * Set this if you want to have access to a minimal set of heap metrics
- * that can be used to guage heap health. Note that enabling this
- * define will add a slight runtime penalty.
- *
  * -D UMM_DBG_LOG_LEVEL=n
  *
  * Set n to a value from 0 to 6 depending on how verbose you want the debug
@@ -64,19 +58,6 @@ extern char test_umm_heap[];
 #undef  UMM_FIRST_FIT
 
 /*
- * -D UMM_METRICS :
- *
- * Enables a minimal set of metrics that can be used to gauge the
- * health of the heap, including:
- *
- * - Percentage of heap used
- * - Percentage heap fragmentation
- * - Largest free block (requires traversal of free list)
- */
-
-#define UMM_METRICS
-
-/*
  * -D UMM_INFO :
  *
  * Enables a dump of the heap contents and a function to return the total
@@ -87,26 +68,14 @@ extern char test_umm_heap[];
 #define UMM_INFO
 
 #ifdef UMM_INFO
-  typedef struct UMM_HEAP_INFO_t {
-    unsigned int totalEntries;
-    unsigned int usedEntries;
-    unsigned int freeEntries;
-
-    unsigned int totalBlocks;
-    unsigned int usedBlocks;
-    unsigned int freeBlocks;
-    unsigned int freeBlocksSquared;
-
-    unsigned int maxFreeContiguousBlocks;
-  }
-  UMM_HEAP_INFO;
-
-  extern UMM_HEAP_INFO ummHeapInfo;
-
-  void *umm_info( void *ptr, bool force );
-  size_t umm_free_heap_size( void );
-  size_t umm_max_free_block_size( void );
-  unsigned int umm_in_use_metric( void );
+  extern void *umm_info( void *ptr, bool force );
+  extern size_t umm_info_total_heap_size( void );
+  extern size_t umm_info_free_heap_size( void );
+  extern size_t umm_info_used_heap_size( void );
+  extern size_t umm_info_max_free_block_size( void );
+  extern size_t umm_info_max_used_block_size( void );
+  extern size_t umm_info_usage_metric( void );
+  extern size_t umm_info_fragmentation_metric( void );
 #else
 #endif
 

--- a/test/test_umm_malloc.c
+++ b/test/test_umm_malloc.c
@@ -844,7 +844,7 @@ TEST_TEAR_DOWN(Metrics)
 TEST(Metrics, Empty)
 {
     umm_info(0, false);
-    TEST_ASSERT_EQUAL (0, umm_fragmentation_metric());
+    TEST_ASSERT_EQUAL (0, umm_info_fragmentation_metric());
 }
 
 TEST(Metrics, Full)
@@ -858,7 +858,7 @@ TEST(Metrics, Full)
     p[i] = umm_malloc(4);
 
   umm_info(0, false);
-  TEST_ASSERT_EQUAL (0, umm_fragmentation_metric());
+  TEST_ASSERT_EQUAL (0, umm_info_fragmentation_metric());
 }
 
 TEST(Metrics, SparseFull)
@@ -875,7 +875,7 @@ TEST(Metrics, SparseFull)
     umm_free(p[i]);
 
   umm_info(0, false);
-  TEST_ASSERT_EQUAL (99, umm_fragmentation_metric());
+  TEST_ASSERT_EQUAL (99, umm_info_fragmentation_metric());
 }
 
 TEST(Metrics, Sparse7of8)
@@ -892,7 +892,7 @@ TEST(Metrics, Sparse7of8)
     umm_free(p[i]);
 
   umm_info(0, false);
-  TEST_ASSERT_EQUAL (78, umm_fragmentation_metric());
+  TEST_ASSERT_EQUAL (78, umm_info_fragmentation_metric());
 }
 
 TEST(Metrics, Sparse3of4)
@@ -909,7 +909,7 @@ TEST(Metrics, Sparse3of4)
     umm_free(p[i]);
 
   umm_info(0, false);
-  TEST_ASSERT_EQUAL (61, umm_fragmentation_metric());
+  TEST_ASSERT_EQUAL (61, umm_info_fragmentation_metric());
 }
 
 TEST(Metrics, Sparse1of2)
@@ -926,7 +926,7 @@ TEST(Metrics, Sparse1of2)
     umm_free(p[i]);
 
   umm_info(0, false);
-  TEST_ASSERT_EQUAL (34, umm_fragmentation_metric());
+  TEST_ASSERT_EQUAL (34, umm_info_fragmentation_metric());
 }
 
 TEST(Metrics, Sparse1of4)
@@ -943,7 +943,7 @@ TEST(Metrics, Sparse1of4)
     umm_free(p[i]);
 
   umm_info(0, false);
-  TEST_ASSERT_EQUAL (15, umm_fragmentation_metric());
+  TEST_ASSERT_EQUAL (15, umm_info_fragmentation_metric());
 }
 
 TEST(Metrics, Sparse1of8)
@@ -960,7 +960,7 @@ TEST(Metrics, Sparse1of8)
     umm_free(p[i]);
 
   umm_info(0, false);
-  TEST_ASSERT_EQUAL (7, umm_fragmentation_metric());
+  TEST_ASSERT_EQUAL (7, umm_info_fragmentation_metric());
 }
 
 TEST_GROUP_RUNNER(Metrics)
@@ -1143,7 +1143,7 @@ TEST(Poison, Stress)
   }
 
   umm_info( 0, true  );
-  DBGLOG_FORCE( true, "Free Heap Size: %ld\n", umm_free_heap_size() );
+  DBGLOG_FORCE( true, "Free Heap Size: %ld\n", umm_info_free_heap_size() );
 }
 
 TEST_GROUP_RUNNER(Poison)


### PR DESCRIPTION
- Removed code in umm_malloc.c that handled updating
  the fragmentation metric in real time
- Moved the umm_info struct definition to umm_info.c
- Added umm_info_xyz() getters for key metrics
- leave only the public getter interface in umm_malloc.h