### PR TITLE
[UMM-29] Move fragmentation metric to umm_info

### DIFF
--- a/src/umm_malloc.c
+++ b/src/umm_malloc.c
@@ -30,6 +30,7 @@
  *                        running in a protected con text. Thanks @devyte
  * R.Hempel 2020-01-07 - Add support for Fragmentation metric - See Issue 14
  * R.Hempel 2020-01-12 - Use explicitly sized values from stdint.h - See Issue 15
+ * R.Hempel 2020-01-20 - Move metric functions back to umm_info - See Issue 29
  * ----------------------------------------------------------------------------
  */
 
@@ -154,50 +155,6 @@ static void umm_disconnect_from_free_list( uint16_t c ) {
 
   UMM_NBLOCK(c) &= (~UMM_FREELIST_MASK);
 }
-
-#ifdef UMM_METRICS
-UMM_H_ATTPACKPRE struct _umm_metrics_t {
-  uint32_t freeBlocks;
-  uint32_t freeBlocksSquared;
-} UMM_H_ATTPACKSUF umm_metrics;
-
-static void umm_fragmentation_metric_init( void ) {
-    umm_metrics.freeBlocks = UMM_NUMBLOCKS - 2;
-    umm_metrics.freeBlocksSquared = umm_metrics.freeBlocks * umm_metrics.freeBlocks;
-}
-
-static void umm_fragmentation_metric_add( uint16_t c ) {
-    uint16_t blocks = (UMM_NBLOCK(c) & UMM_BLOCKNO_MASK) - c;
-    DBGLOG_DEBUG( "Add block %i size %i to free metric\n", c, blocks);
-    umm_metrics.freeBlocks += blocks;
-    umm_metrics.freeBlocksSquared += (blocks * blocks);
-}
-
-static void umm_fragmentation_metric_remove( uint16_t c ) {
-    uint16_t blocks = (UMM_NBLOCK(c) & UMM_BLOCKNO_MASK) - c;
-    DBGLOG_DEBUG( "Remove block %i size %i from free metric\n", c, blocks);
-    umm_metrics.freeBlocks -= blocks;
-    umm_metrics.freeBlocksSquared -= (blocks * blocks);
-}
-
-int umm_fragmentation_metric_freeblocks( void ) {
-    return umm_metrics.freeBlocks;
-}
-
-int umm_fragmentation_metric( void ) {
-  DBGLOG_DEBUG( "freeBlocks %i freeBlocksSquared %i\n", umm_metrics.freeBlocks, umm_metrics.freeBlocksSquared);
-  if (0 == umm_metrics.freeBlocks) {
-      return 0;
-  } else {
-      return (100 - (((uint32_t)(sqrtf(umm_metrics.freeBlocksSquared)) * 100)/(umm_metrics.freeBlocks)));
-  }
-}
-
-#else
-  #define umm_fragmentation_metric_init()
-  #define umm_fragmentation_metric_add(c)
-  #define umm_fragmentation_metric_remove(c)
-#endif // UMM_METRICS
 
 /* ------------------------------------------------------------------------
  * The umm_assimilate_up() function does not assume that UMM_NBLOCK(c)

--- a/src/umm_malloc_cfg.h
+++ b/src/umm_malloc_cfg.h
@@ -49,11 +49,11 @@
 
 #ifdef TEST_BUILD
 extern char test_umm_heap[];
-#endif
 
 /* Start addresses and the size of the heap */
 #define UMM_MALLOC_CFG_HEAP_ADDR (test_umm_heap)
 #define UMM_MALLOC_CFG_HEAP_SIZE 0x10000
+#endif
 
 /* A couple of macros to make packing structures less compiler dependent */
 
@@ -75,6 +75,15 @@ extern char test_umm_heap[];
  */
 
 #define UMM_METRICS
+
+#ifdef UMM_METRICS
+  extern int umm_fragmentation_metric( void );
+#else
+  #define umm_fragmentation_metric_init()
+  #define umm_fragmentation_metric_add(c)
+  #define umm_fragmentation_metric_remove(c)
+  #define umm_fragmentation_metric() (0)
+#endif // UMM_METRICS
 
 /*
  * -D UMM_INFO :
@@ -103,11 +112,15 @@ extern char test_umm_heap[];
 
   extern UMM_HEAP_INFO ummHeapInfo;
 
-  void *umm_info( void *ptr, bool force );
-  size_t umm_free_heap_size( void );
-  size_t umm_max_free_block_size( void );
-  unsigned int umm_in_use_metric( void );
+  extern void *umm_info( void *ptr, bool force );
+  extern size_t umm_free_heap_size( void );
+  extern size_t umm_max_free_block_size( void );
+  extern unsigned int umm_in_use_metric( void );
 #else
+  #define umm_info(p,b)
+  #define umm_free_heap_size() (0)
+  #define umm_max_free_block_size() (0)
+  #define umm_in_use_metric() (0)
 #endif
 
 /*

--- a/src/umm_malloc_cfg.h
+++ b/src/umm_malloc_cfg.h
@@ -157,7 +157,7 @@ extern char test_umm_heap[];
    extern void umm_corruption(void);
 #  define UMM_HEAP_CORRUPTION_CB() printf( "Heap Corruption!" )
 #else
-#  define INTEGRITY_CHECK() 0
+#  define INTEGRITY_CHECK() 1
 #endif
 
 /*
@@ -202,7 +202,7 @@ extern char test_umm_heap[];
    bool  umm_poison_check( void );
 #  define POISON_CHECK() umm_poison_check()
 #else
-#  define POISON_CHECK() 0
+#  define POISON_CHECK() 1
 #endif
 
 #endif /* _UMM_MALLOC_CFG_H */

--- a/test/test_umm_malloc.c
+++ b/test/test_umm_malloc.c
@@ -1002,6 +1002,7 @@ TEST_TEAR_DOWN(Metrics)
 
 TEST(Metrics, Empty)
 {
+    TEST_ASSERT_EQUAL (0, umm_fragmentation_metric());
     umm_info(0, false);
     TEST_ASSERT_EQUAL (0, umm_fragmentation_metric());
 }
@@ -1016,6 +1017,7 @@ TEST(Metrics, Full)
   for( i=0; i<(UMM_LASTBLOCK-1); ++i )
     p[i] = umm_malloc(4);
 
+  TEST_ASSERT_EQUAL (0, umm_fragmentation_metric());
   umm_info(0, false);
   TEST_ASSERT_EQUAL (0, umm_fragmentation_metric());
 }
@@ -1033,6 +1035,7 @@ TEST(Metrics, SparseFull)
   for( i=1; i<(UMM_LASTBLOCK); i+=2 )
     umm_free(p[i]);
 
+  TEST_ASSERT_EQUAL (99, umm_fragmentation_metric());
   umm_info(0, false);
   TEST_ASSERT_EQUAL (99, umm_fragmentation_metric());
 }
@@ -1050,6 +1053,7 @@ TEST(Metrics, Sparse7of8)
   for( i=1; i<((UMM_LASTBLOCK*7)/8); i+=2 )
     umm_free(p[i]);
 
+  TEST_ASSERT_EQUAL (78, umm_fragmentation_metric());
   umm_info(0, false);
   TEST_ASSERT_EQUAL (78, umm_fragmentation_metric());
 }
@@ -1067,6 +1071,7 @@ TEST(Metrics, Sparse3of4)
   for( i=1; i<((UMM_LASTBLOCK*3)/4); i+=2 )
     umm_free(p[i]);
 
+  TEST_ASSERT_EQUAL (61, umm_fragmentation_metric());
   umm_info(0, false);
   TEST_ASSERT_EQUAL (61, umm_fragmentation_metric());
 }
@@ -1084,6 +1089,7 @@ TEST(Metrics, Sparse1of2)
   for( i=1; i<((UMM_LASTBLOCK*1)/2); i+=2 )
     umm_free(p[i]);
 
+  TEST_ASSERT_EQUAL (34, umm_fragmentation_metric());
   umm_info(0, false);
   TEST_ASSERT_EQUAL (34, umm_fragmentation_metric());
 }
@@ -1101,6 +1107,7 @@ TEST(Metrics, Sparse1of4)
   for( i=1; i<((UMM_LASTBLOCK*1)/4); i+=2 )
     umm_free(p[i]);
 
+  TEST_ASSERT_EQUAL (15, umm_fragmentation_metric());
   umm_info(0, false);
   TEST_ASSERT_EQUAL (15, umm_fragmentation_metric());
 }
@@ -1118,6 +1125,7 @@ TEST(Metrics, Sparse1of8)
   for( i=1; i<((UMM_LASTBLOCK*1)/8); i+=2 )
     umm_free(p[i]);
 
+  TEST_ASSERT_EQUAL (7, umm_fragmentation_metric());
   umm_info(0, false);
   TEST_ASSERT_EQUAL (7, umm_fragmentation_metric());
 }
@@ -1252,7 +1260,9 @@ static void runAllTests (void)
     RUN_TEST_GROUP(MultiMalloc);
     RUN_TEST_GROUP(Free);
     RUN_TEST_GROUP(Realloc);
+#ifdef UMM_METRICS
     RUN_TEST_GROUP(Metrics);
+#endif
     RUN_TEST_GROUP(Poison);
 }
 


### PR DESCRIPTION
@d-a-v and @devyte this PR leaves the inline fragmentation metric in place and also provides a full umm_info() metric option that does a full traversal of the heap to give complete metrics including number of free and used blocks, largest free and used blocks, fragmentation and utilization metrics.

Next up is a rework of the config system so that we control how the project is built at compile time, which eliminates the need for changing any files.