### PR TITLE
Make possible to change UMM_H_ATTPACKPRE/SUF with config header

### DIFF
--- a/src/umm_malloc_cfg.h
+++ b/src/umm_malloc_cfg.h
@@ -136,8 +136,12 @@
 
 /* A couple of macros to make packing structures less compiler dependent */
 
-#define UMM_H_ATTPACKPRE
-#define UMM_H_ATTPACKSUF __attribute__((__packed__))
+#ifndef UMM_H_ATTPACKPRE
+    #define UMM_H_ATTPACKPRE
+#endif
+#ifndef UMM_H_ATTPACKSUF
+    #define UMM_H_ATTPACKSUF __attribute__((__packed__))
+#endif
 
 /* -------------------------------------------------------------------------- */
 


### PR DESCRIPTION
This PR allows with help of `#ifndef` to set the following macro in `umm_malloc_cfgport.h`:

```
#define UMM_H_ATTPACKPRE __packed
#define UMM_H_ATTPACKSUF
```
It is needed to compile with IAR 7.50.1 on ARM (it works on IAR 9).