### PR TITLE
Fix pointer arithmetic (invalid use of void in umm_poison_*)

### DIFF
--- a/src/umm_poison.c
+++ b/src/umm_poison.c
@@ -72,7 +72,7 @@ static bool check_poison_block(umm_block *pblock) {
         DBGLOG_ERROR("check_poison_block is called for free block 0x%08x\n", DBGLOG_32_BIT_PTR(pblock));
     } else {
         /* the block is used; let's check poison */
-        void *pc = (void *)pblock->body.data;
+        uint8_t *pc = pblock->body.data;
         void *pc_cur;
 
         pc_cur = pc + sizeof(UMM_POISONED_BLOCK_LEN_TYPE);
@@ -103,16 +103,16 @@ static void *get_poisoned(void *ptr, size_t size_w_poison) {
     if (size_w_poison != 0 && ptr != NULL) {
 
         /* Poison beginning and the end of the allocated chunk */
-        put_poison(ptr + sizeof(UMM_POISONED_BLOCK_LEN_TYPE),
+        put_poison((uint8_t *)ptr + sizeof(UMM_POISONED_BLOCK_LEN_TYPE),
             UMM_POISON_SIZE_BEFORE);
-        put_poison(ptr + size_w_poison - UMM_POISON_SIZE_AFTER,
+        put_poison((uint8_t *)ptr + size_w_poison - UMM_POISON_SIZE_AFTER,
             UMM_POISON_SIZE_AFTER);
 
         /* Put exact length of the user's chunk of memory */
         *(UMM_POISONED_BLOCK_LEN_TYPE *)ptr = (UMM_POISONED_BLOCK_LEN_TYPE)size_w_poison;
 
         /* Return pointer at the first non-poisoned byte */
-        return ptr + sizeof(UMM_POISONED_BLOCK_LEN_TYPE) + UMM_POISON_SIZE_BEFORE;
+        return (uint8_t *)ptr + sizeof(UMM_POISONED_BLOCK_LEN_TYPE) + UMM_POISON_SIZE_BEFORE;
     } else {
         return ptr;
     }
@@ -128,10 +128,10 @@ static void *get_unpoisoned(void *ptr) {
     if (ptr != NULL) {
         uint16_t c;
 
-        ptr -= (sizeof(UMM_POISONED_BLOCK_LEN_TYPE) + UMM_POISON_SIZE_BEFORE);
+        ptr = (uint8_t *)ptr - (sizeof(UMM_POISONED_BLOCK_LEN_TYPE) + UMM_POISON_SIZE_BEFORE);
 
         /* Figure out which block we're in. Note the use of truncated division... */
-        c = (((void *)ptr) - (void *)(&(UMM_HEAP[0]))) / UMM_BLOCKSIZE;
+        c = (((uint8_t *)ptr) - (uint8_t *)(&(UMM_HEAP[0]))) / UMM_BLOCKSIZE;
 
         check_poison_block(&UMM_BLOCK(c));
     }


### PR DESCRIPTION
Fixes pointer arithmetic (uses `void *` instead of valid type).

Similar to #57, but for umm_poison.c.