### PR TITLE
Add support for multi-heaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ GitHub users @d-a-v and @devyte provided great input on establishing
 a heap fragmentation metric which they graciously allowed to be used
 in umm_malloc.
 
+Katherine Whitlock (@stellar-aria) extended the library for usage in 
+scenarios where more than one heap or memory space is needed.
+
 ## Usage
 
 This library is designed to be included in your application as a
@@ -66,7 +69,18 @@ We can also call `umm_init_heap(void *pheap, size_t size)` where the
 heap details are passed in manually. This is useful in systems where
 you can allocate a block of memory at run time - for example in Rust.
 
-> :black_square_button: Future development may allow for multiple heaps
+### Multiple heaps
+
+For usage in a scenario that requires multiple heaps, the heap type
+`umm_heap` is exposed. All API functions (`malloc`, `free`, `realloc`, etc.) 
+have a corresponding `umm_multi_*` variant that take a pointer to this 
+type as their first parameter.
+
+Much like standard initialization, there are two methods:
+   - `umm_multi_init(umm_heap *heap)`, which initializes a given heap
+    using linker symbols
+   - `umm_multi_init_heap(umm_heap *heap, void *ptr, size_t size)`, which
+    will initialize a given heap using a known address and size.
 
 ## Automated Testing
 
@@ -128,18 +142,40 @@ making changes to the code.
 
 The following functions are available for your application:
 
-- `void *umm_malloc( size_t size );`
-- `void *umm_calloc( size_t num, size_t size );`
-- `void *umm_realloc( void *ptr, size_t size );`
-- `void  umm_free( void *ptr );`
+```c
+void *umm_malloc(size_t size)
+void *umm_calloc(size_t num, size_t size)
+void *umm_realloc(void *ptr, size_t size)
+void  umm_free(void *ptr)
+```
 
 They have exactly the same semantics as the corresponding standard library
 functions.
 
 To initialize the library there are two options:
 
-- `void *umm_malloc( size_t size );`
+```c
+void  umm_init(void)
+void  umm_init_heap(void *ptr, size_t size)
+```
 
+### Multi-Heap API
+
+For the case of multiple heaps, corresponding `umm_multi_*` functions are provided.
+
+```c
+void *umm_multi_malloc(umm_heap *heap, size_t size)
+void *umm_multi_calloc(umm_heap *heap, size_t num, size_t size)
+void *umm_multi_realloc(umm_heap *heap, void *ptr, size_t size)
+void  umm_multi_free(umm_heap *heap, void *ptr)
+```
+
+As with the standard API, there are two options for initialization:
+
+```c
+void  umm_multi_init(umm_heap *heap)
+void  umm_multi_init_heap(umm_heap *heap, void *ptr, size_t size)
+```
  
 ## Background
 

--- a/src/umm_integrity.c
+++ b/src/umm_integrity.c
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+extern umm_heap umm_heap_current;
+
 /*
  * Perform integrity check of the whole heap data. Returns 1 in case of
  * success, 0 otherwise.
@@ -27,6 +29,10 @@
  * chain.
  */
 bool umm_integrity_check(void) {
+ return umm_multi_integrity_check(&umm_heap_current);
+}
+
+bool umm_multi_integrity_check(umm_heap* heap) {
     UMM_CRITICAL_DECL(id_integrity);
     bool ok = true;
     uint16_t prev;

--- a/src/umm_malloc.c
+++ b/src/umm_malloc.c
@@ -34,6 +34,7 @@
  * R.Hempel 2020-02-01 - Macro functions are uppercased - See Issue 34
  * R.Hempel 2020-06-20 - Support alternate body size - See Issue 42
  * R.Hempel 2021-05-02 - Support explicit memory umm_init_heap() - See Issue 53
+ * K.Whitlock 2023-07-06 - Add support for multiple heaps
  * ----------------------------------------------------------------------------
  */
 

--- a/src/umm_malloc.h
+++ b/src/umm_malloc.h
@@ -9,10 +9,27 @@
 #define UMM_MALLOC_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* ------------------------------------------------------------------------ */
+
+typedef struct umm_heap_config {
+    void *pheap;
+    size_t heap_size;
+    uint16_t numblocks;
+} umm_heap;
+
+extern void  umm_multi_init_heap(umm_heap *heap, void *ptr, size_t size);
+extern void  umm_multi_init(umm_heap *heap);
+
+extern void *umm_multi_malloc(umm_heap *heap, size_t size);
+extern void *umm_multi_calloc(umm_heap *heap, size_t num, size_t size);
+extern void *umm_multi_realloc(umm_heap *heap, void *ptr, size_t size);
+extern void  umm_multi_free(umm_heap *heap, void *ptr);
 
 /* ------------------------------------------------------------------------ */
 

--- a/src/umm_malloc_cfg.h
+++ b/src/umm_malloc_cfg.h
@@ -134,6 +134,9 @@
 #include <umm_malloc_cfgport.h>
 #endif
 
+/* Forward declaration of umm_heap_config */
+struct umm_heap_config;
+
 /* A couple of macros to make packing structures less compiler dependent */
 
 #ifndef UMM_H_ATTPACKPRE
@@ -198,6 +201,9 @@
 /* -------------------------------------------------------------------------- */
 
 #ifdef UMM_INLINE_METRICS
+  #define UMM_MULTI_FRAGMENTATION_METRIC_INIT(h) umm_multi_fragmentation_metric_init(h)
+  #define UMM_MULTI_FRAGMENTATION_METRIC_ADD(h,c) umm_multi_fragmentation_metric_add(h,c)
+  #define UMM_MULTI_FRAGMENTATION_METRIC_REMOVE(h,c) umm_multi_fragmentation_metric_remove(h,c)
   #define UMM_FRAGMENTATION_METRIC_INIT() umm_fragmentation_metric_init()
   #define UMM_FRAGMENTATION_METRIC_ADD(c) umm_fragmentation_metric_add(c)
   #define UMM_FRAGMENTATION_METRIC_REMOVE(c) umm_fragmentation_metric_remove(c)
@@ -232,12 +238,22 @@ UMM_HEAP_INFO;
 
 extern UMM_HEAP_INFO ummHeapInfo;
 
+extern void *umm_multi_info(struct umm_heap_config *heap, void *ptr, bool force);
+extern size_t umm_multi_free_heap_size(struct umm_heap_config *heap);
+extern size_t umm_multi_max_free_block_size(struct umm_heap_config *heap);
+extern int umm_multi_usage_metric(struct umm_heap_config *heap);
+extern int umm_multi_fragmentation_metric(struct umm_heap_config *heap);
 extern void *umm_info(void *ptr, bool force);
 extern size_t umm_free_heap_size(void);
 extern size_t umm_max_free_block_size(void);
 extern int umm_usage_metric(void);
 extern int umm_fragmentation_metric(void);
 #else
+  #define umm_multi_info(h,p,b)
+  #define umm_multi_free_heap_size(h) (0)
+  #define umm_multi_max_free_block_size(h) (0)
+  #define umm_multi_usage_metric(h) (0)
+  #define umm_multi_fragmentation_metric(h) (0)
   #define umm_info(p,b)
   #define umm_free_heap_size() (0)
   #define umm_max_free_block_size() (0)
@@ -303,6 +319,7 @@ extern int umm_max_critical_depth;
  */
 
 #ifdef UMM_INTEGRITY_CHECK
+extern bool umm_multi_integrity_check(struct umm_heap_config *heap);
 extern bool umm_integrity_check(void);
 #define INTEGRITY_CHECK() umm_integrity_check()
 extern void umm_corruption(void);
@@ -342,6 +359,12 @@ extern void umm_corruption(void);
   #define UMM_POISON_SIZE_BEFORE (4)
   #define UMM_POISON_SIZE_AFTER (4)
   #define UMM_POISONED_BLOCK_LEN_TYPE uint16_t
+
+extern void *umm_multi_poison_malloc(struct umm_heap_config *heap, size_t size);
+extern void *umm_multi_poison_calloc(struct umm_heap_config *heap, size_t num, size_t size);
+extern void *umm_multi_poison_realloc(struct umm_heap_config *heap, void *ptr, size_t size);
+extern void  umm_multi_poison_free(struct umm_heap_config *heap, void *ptr);
+extern bool  umm_multi_poison_check(struct umm_heap_config *heap);
 
 extern void *umm_poison_malloc(size_t size);
 extern void *umm_poison_calloc(size_t num, size_t size);


### PR DESCRIPTION
This adds support for multi-heaps, similar to dlmalloc's mspace functionality. Rather than relying on umm_malloc to do the coordination on whether or not a pointer belongs in a specific heap, the coordination (and storage of the `umm_heap[_config]`) is left to the caller. This allows for easy wrapping to an OO style interface instead of a C one if the user desires.

## Why?
I was investigating memory allocators specifically for an ARMv7 (Cortex-A9) project that has two separate RAM regions (internal and SDRAM), and this seemed perfect except for the lack of multi-heap support.

## Changes:
- moved `umm_heap_config` declaration to `umm_malloc.h` to allow for known storage size by caller.
  - changed `pheap` field to be `void*` instead of `umm_block` since I thought it was unnecessary to move more structure definitions to the header, and it's assigned from a `void*` anyways
- re-defined macros to point to new parameter `heap` that is now passed to all internal functions rather than relying on the `umm_heap_current`
- moved global `umm_heap_config umm_heap_current`
- added to `umm_malloc.c` new proxy functions that simply call `umm_multi_*` functions with the moved `umm_heap_config umm_heap_current`
- added relevant `multi_*` functions and single-heap proxies to info, integrity, and poison

I ran the tests on my machine, but I don't know if there's a CI action set up here or not.

As of 563d7f7 all tests pass for me.